### PR TITLE
Support configuring more OpenStack auth fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ example, a dict of the form:
 * `username`: OpenStack username.
 * `password`: OpenStack password.
 
+The dict *may* also include the following, optional variables:
+* `project_domain_name`: OpenStack project domain name. Defaults to "Default".
+* `region_name`: OpenStack region name. Defaults to "RegionOne".
+* `user_domain_name`: OpenStack user domain name. Defaults to "Default".
+* `service_type`: OpenStack monitoring service type. Defaults to "monitoring".
+* `endpoint_type`: OpenStack monitoring endpoint type. Defaults to "public".
+
 `monasca_rsyslog_packages_install`: Flag to define whether package dependencies
 for creating a python virtualenv should be installed in the host OS.
 defaults to `True`.

--- a/templates/monasca-rsyslog.conf.j2
+++ b/templates/monasca-rsyslog.conf.j2
@@ -23,6 +23,11 @@ auth_url =  {{monasca_rsyslog_api_auth.auth_url}}
 username = {{monasca_rsyslog_api_auth.username}}
 password = {{monasca_rsyslog_api_auth.password}}
 project_name = {{monasca_rsyslog_api_auth.project}}
+project_domain_name = {{ monasca_rsyslog_api_auth.project_domain_name|default("Default") }}
+region_name: {{ monasca_rsyslog_api_auth.region_name|default("RegionOne") }}
+user_domain_name: {{ monasca_rsyslog_api_auth.user_domain_name|default("Default") }}
+service_type: {{ monasca_rsyslog_api_auth.service_type|default("monitoring") }}
+endpoint_type: {{ monasca_rsyslog_api_auth.endpoint_type|default("public") }}
 
 # Additional configuration parameters. Currently it is required that
 # the monasca-log-api endpoint is specified here.


### PR DESCRIPTION
We could specify null defaults if we want to minimise the impact this has on anyone.