### PR TITLE
Fix config permissions for Monasca rsyslog plugin

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,3 +27,6 @@ monasca_rsyslog_debian_packages:
   - python2.7-dev
   - python-pip
   - python-virtualenv
+
+monasca_user: "monasca"
+monasca_group: "monasca"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,22 +47,38 @@
     name: git+https://github.com/stackhpc/monasca-rsyslog#egg=monasca-rsyslog
     virtualenv: "{{ monasca_rsyslog_venv or omit }}"
 
+- name: Ensure {{ monasca_group }} group exists
+  group:
+    name: "{{ monasca_group }}"
+    state: present
+
+- name: Ensure {{ monasca_user }} user exists
+  user:
+    name: "{{ monasca_user }}"
+    group: "{{ monasca_group }}"
+
+- name: Add syslog user to monasca group for rsyslog-monasca plugin
+  user:
+    name: "syslog"
+    groups: "{{ monasca_group }}"
+    append: yes
+
 - name: Ensure the Monasca config directory exists
   file:
     path: "{{ monasca_rsyslog_config | dirname }}"
     state: directory
     mode: 0750
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user_gid }}"
+    owner: "{{ monasca_user }}"
+    group: "{{ monasca_group }}"
   become: True
 
 - name: Write the Monasca-rsyslog config file
   template:
     src: monasca-rsyslog.conf.j2
     dest: "{{ monasca_rsyslog_config }}"
-    mode: 0600
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user_gid }}"
+    mode: 0640
+    owner: "{{ monasca_user }}"
+    group: "{{ monasca_group }}"
   notify:
     - Restart rsyslogd
 


### PR DESCRIPTION
The Monasca rsyslog plugin shares a config folder with the Monasca
Agent. The plugin runs as the syslog user, so the syslog user
must be able to read the config file. This changes adds the syslog
user to a Monasca group therefore granting it access.

An alternative with slightly better security could be to move the
plugin config to a separate directory and give only syslog access
to that. However, the secrets used by the rsyslog plugin are
normally the same as those used by the Monasca Agent.