### PR TITLE
Do not strip newline in monasca-rsyslog.conf

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,6 +79,7 @@
     mode: 0640
     owner: "{{ monasca_user }}"
     group: "{{ monasca_group }}"
+    trim_blocks: false
   notify:
     - Restart rsyslogd
 


### PR DESCRIPTION
By default, ansible (actually jinja2) will strip the newline from a template after a loop. To prevent this, we need to disable ```trim_blocks``` for the template