### PR TITLE
Feature/custom logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ for an EPEL-enabled CentOS distribution.
 support, and enable the building of some dependencies within a virtualenv by pip suitable
 for a Debian distribution.
 
+`monasca_rsyslog_custom_template_folder`: Folder, relative to the playbook which runs
+this role containing custom rsyslog templates. For example, this may be used to ingest
+system logs which aren't managed by rsyslog.
+
 Dependencies
 ------------
 
@@ -66,8 +70,7 @@ The following playbook connects an rsyslog deployment with an output plugin for 
 	    auth_url: "http://openstack-keystone:5000"
 	    project: "monasca"
 	    username: "monasca-agent"
-	    password: "XXXX"
-	  monasca_rsyslog_api_endpoint: "http://monasca-log-api:5607/v3.0/"
+	    password: "{{ vault_encypted_monasca_agent_password }}"
 	  monasca_rsyslog_venv: "/usr/libexec/monasca-rsyslog"
 
 Author Information

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,11 @@ monasca_rsyslog_api_max_batch_size: 100
 # Minimum time to wait between positing logs to logging api
 monasca_rsyslog_api_min_poll_delay: 10
 
+# Folder, relative to the playbook which runs this role containing
+# custom rsyslog templates. For example, this may be used to ingest
+# system logs which aren't managed by rsyslog.
+monasca_rsyslog_custom_template_folder: monasca_rsyslog_custom_templates
+
 # List of package dependencies.
 monasca_rsyslog_rhel_packages:
   - gcc

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -83,20 +83,32 @@
   notify:
     - Restart rsyslogd
 
-- name: Deploy rsyslogd template
+- name: Deploy Monasca rsyslogd templates
   template:
-    src: 50-monasca-rsyslog-template.conf.j2
-    dest: /etc/rsyslog.d/50-monasca-rsyslog-template.conf
+    src: "{{ item }}.j2"
+    dest: "/etc/rsyslog.d/{{ item }}"
     mode: 0644
   become: True
+  with_items:
+    - 50-monasca-rsyslog-template.conf
+    - 60-monasca-rsyslog-omprog.conf
   notify:
     - Restart rsyslogd
 
-- name: Deploy rsyslogd template
+- name: Find custom rsyslogd templates
+  find:
+    paths: "{{ playbook_dir }}/{{ monasca_rsyslog_custom_template_folder }}"
+    patterns: '*.conf'
+  delegate_to: localhost
+  run_once: True
+  register: monasca_rsyslog_custom_templates
+
+- name: Deploy custom templates
   template:
-    src: 60-monasca-rsyslog-omprog.conf.j2
-    dest: /etc/rsyslog.d/60-monasca-rsyslog-omprog.conf
+    src: "{{ item.path }}"
+    dest: "/etc/rsyslog.d/{{ item.path | basename }}"
     mode: 0644
   become: True
+  with_items: "{{  monasca_rsyslog_custom_templates.files }}"
   notify:
     - Restart rsyslogd


### PR DESCRIPTION
In this case, the motivation is to get Ceph logs into Monasca. (We could of course configure Ceph to push to rsyslog directly, but this approach has advantages)